### PR TITLE
Correcting the documentation for dotted notes.

### DIFF
--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -262,7 +262,7 @@ tabstave
       <p/>
       For example, <code>:w</code> specifies a whole note. The currently available
       durations are: <code>w h q 8 16 32</code>, for whole, half, quarter, eighth,
-      sixteenth, and thirty-second note durations. Suffixing a dot to the duration indicates a dotted note.
+      sixteenth, and thirty-second note durations. Suffixing a 'd' to the duration indicates a dotted note. For example, <code>:qd</code>.
       <p/>
       You can indicate tuplets by enclosing a tuplet number (3, 5, 7, etc.) within caret signs (<code>^</code>). VexTab will create a tuplet out of the preceding notes. For example, <code>:8 4-5-6/4 ^3^</code> will create
       a triplet out of three notes.


### PR DESCRIPTION
The documentation for creating dotted notes seems to be incorrect. This should fix it.
