### PR TITLE
added 'clef=none' option

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -905,18 +905,19 @@ class Vex.Flow.Artist
     tabstave_start_x = 40
 
     if opts.notation is "true"
-      note_stave = new Vex.Flow.Stave(@x, @last_y, @customizations.width - 20).
-        addClef(opts.clef).addKeySignature(opts.key)
+      note_stave = new Vex.Flow.Stave(@x, @last_y, @customizations.width - 20).addKeySignature(opts.key);
+      note_stave.addClef(opts.clef) if opts.clef isnt "none"
       note_stave.addTimeSignature(opts.time) if opts.time?
       @last_y += note_stave.getHeight() +
                  @options.note_stave_lower_spacing +
                  parseInt(@customizations["stave-distance"], 10)
       tabstave_start_x = note_stave.getNoteStartX()
-      @current_clef = opts.clef
+      @current_clef = if opts.clef is "none" then "treble" else opts.clef
 
     if opts.tablature is "true"
       tab_stave = new Vex.Flow.TabStave(@x, @last_y, @customizations.width - 20).
-        addTabGlyph().setNoteStartX(tabstave_start_x)
+        setNoteStartX(tabstave_start_x)
+      tab_stave.addTabGlyph() if opts.clef isnt "none"
       @last_y += tab_stave.getHeight() + @options.tab_stave_lower_spacing
 
     @closeBends()

--- a/src/vextab.coffee
+++ b/src/vextab.coffee
@@ -43,7 +43,7 @@ class Vex.Flow.VexTab
         when "key"
           throw error("Invalid key signature '#{option.value}'") unless _.has(Vex.Flow.keySignature.keySpecs, option.value)
         when "clef"
-          clefs = ["treble", "bass", "tenor", "alto", "percussion"]
+          clefs = ["treble", "bass", "tenor", "alto", "percussion", "none"]
           throw error("'clef' must be one of #{clefs.join(', ')}") if option.value not in clefs
         when "voice"
           voices = ["top", "bottom", "new"]


### PR DESCRIPTION
hi
with this option not clef on notation stave nor on tab glyph on tabstave are displayed, like this: 
![image](https://f.cloud.github.com/assets/1554577/1643452/0021b3b2-58c7-11e3-8257-e7ec62cc9b42.png)
