### PR TITLE
Player breaks when Raphael js is present

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -8,7 +8,7 @@ class Vex.Flow.Artist
   @DEBUG = false
   L = (args...) -> console?.log("(Vex.Flow.Artist)", args...) if Vex.Flow.Artist.DEBUG
 
-  @NOLOGO = false
+  @NOLOGO = true
 
   constructor: (@x, @y, @width, options) ->
     @options =

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -77,34 +77,25 @@ class Vex.Flow.Player
     @stop()
 
   getOverlay = (context, scale, overlay_class) ->
-    
+
+    overlay = $('<canvas>')
+    overlay.css("position", "absolute")
+    overlay.css("left", 0)
+    overlay.css("top", 0)
+    #overlay.css("cursor", "pointer")
+    overlay.addClass(overlay_class)    
+
     if context.canvas?
       canvas = context.canvas
       height = canvas.height
       width = canvas.width
-      overlay = $('<canvas>')
-      overlay.css("position", "absolute")
-      overlay.css("left", 0)
-      overlay.css("top", 0)
-      overlay.addClass(overlay_class)
 
-      console.log "setting up overlay in canvas"
       $(canvas).after(overlay)
       ctx = Vex.Flow.Renderer.getCanvasContext(overlay.get(0), width, height)
       ctx.scale(scale, scale)
     
     else
-      canvas = context
-      height = context.height
-      width = context.width
-        
-      overlay = $('<canvas>')
-      overlay.css("position", "absolute")
-      overlay.css("left", 0)
-      overlay.css("top", 0)
-      overlay.addClass(overlay_class)
-
-      $(canvas.element).after(overlay)
+      $(context.element).after(overlay)
     
     ps = new paper.PaperScope()
     ps.setup(overlay.get(0))

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -77,20 +77,35 @@ class Vex.Flow.Player
     @stop()
 
   getOverlay = (context, scale, overlay_class) ->
-    canvas = context.canvas
-    height = canvas.height
-    width = canvas.width
+    
+    if context.canvas?
+      canvas = context.canvas
+      height = canvas.height
+      width = canvas.width
+      overlay = $('<canvas>')
+      overlay.css("position", "absolute")
+      overlay.css("left", 0)
+      overlay.css("top", 0)
+      overlay.addClass(overlay_class)
 
-    overlay = $('<canvas>')
-    overlay.css("position", "absolute")
-    overlay.css("left", 0)
-    overlay.css("top", 0)
-    overlay.addClass(overlay_class)
+      console.log "setting up overlay in canvas"
+      $(canvas).after(overlay)
+      ctx = Vex.Flow.Renderer.getCanvasContext(overlay.get(0), width, height)
+      ctx.scale(scale, scale)
+    
+    else
+      canvas = context
+      height = context.height
+      width = context.width
+        
+      overlay = $('<canvas>')
+      overlay.css("position", "absolute")
+      overlay.css("left", 0)
+      overlay.css("top", 0)
+      overlay.addClass(overlay_class)
 
-    $(canvas).after(overlay)
-    ctx = Vex.Flow.Renderer.getCanvasContext(overlay.get(0), width, height)
-    ctx.scale(scale, scale)
-
+      $(canvas.element).after(overlay)
+    
     ps = new paper.PaperScope()
     ps.setup(overlay.get(0))
 


### PR DESCRIPTION
I wrote a small adition to handle Raphael Context at the player.
The issue was that when the frerboard was added, as it needs Raphael.js, this broke the player display. The player was missing the handling of SVG case.
