### PR TITLE
fix broken merge of #16 (added 'clef=none' option)

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -956,7 +956,7 @@ class Vex.Flow.Artist
     start_x = @x + @customizations["connector-space"]
     tabstave_start_x = 40
 
-   if opts.notation is "true"
+    if opts.notation is "true"
       note_stave = new Vex.Flow.Stave(start_x, @last_y, @customizations.width - 20).
         addKeySignature(opts.key)
       note_stave.addClef(opts.clef) if opts.clef isnt "none"


### PR DESCRIPTION
merge of https://github.com/0xfe/vextab/pull/16 was broken in https://github.com/0xfe/vextab/commit/a60809ee54ee07d4f7e90d6e116d04204a6202c1
