### PR TITLE
Ignore both "build" and "build/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
-build/*
+build
+build/
 Gemfile.lock
 
 *.lock


### PR DESCRIPTION
This is helpful because I often bypass the building process by creating a symlink from build/ to releases/ and it is best if git ignores a symlink (which is a file) just like it ignores a directory.