### PR TITLE
Support rendering new time signature mid-stave

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -794,6 +794,14 @@ class Artist
     else
       tab_notes.push new Vex.Flow.GhostNote(@current_duration)
 
+  addTimeSigNote: (value) ->
+    L "addTimeSig", value
+    stave = _.last(@staves)
+
+    timesig_note = new Vex.Flow.TimeSigNote(value)
+    stave.tab_notes.push(timesig_note)
+    stave.note_notes.push(timesig_note) if stave.note?
+
   addChord: (chord, chord_articulation, chord_decorator) ->
     return if _.isEmpty(chord)
     L "addChord: ", chord

--- a/src/vextab.coffee
+++ b/src/vextab.coffee
@@ -85,6 +85,9 @@ class VexTab
     if element.command is "rest"
       @artist.addRest(element.params)
 
+    if element.command is "timesignote"
+      @artist.addTimeSigNote(element.value)
+
     if element.command is "command"
       @artist.runCommand(element.params, element._l, element._c)
 

--- a/src/vextab.jison
+++ b/src/vextab.jison
@@ -50,6 +50,7 @@
 "."                       return '.'
 "#"                       return '#'
 "@"                       return '@'
+"*"                       return '*'
 
 /* These are valid inside fret/string expressions only */
 
@@ -273,6 +274,14 @@ lingo
         params: $1
       }]
     }
+  | timesignote
+    { $$ = [{
+        command: "timesignote",
+        value: $1,
+        _l: @1.first_line,
+        _c: @1.first_column
+        }]
+    }
   ;
 
 bar
@@ -421,6 +430,10 @@ rest
   : '#' '#'             { $$ = {position: 0} }
   | '#' NUMBER '#'      { $$ = {position: $2} }
   | '#' '-' NUMBER '#'  { $$ = {position: $3 * -1} }
+  ;
+
+timesignote
+  : '*' NUMBER '/' NUMBER '*'   { $$ = $2 + '/' + $4 }
   ;
 
 abc

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -45,7 +45,7 @@
     <textarea id="blah">options space=20 tab-stems=true stave-distance=40 tab-stem-direction=down
 tabstave notation=true key=A time=4/4
 notes :q =|: (5/2.5/3.7/4) :8 7-5h6/3 ^3^ 5h6-7/5 ^3^ :q 7V/4 |
-notes :8 t12p7/4 s5s3/4 :8 3s:16:5-7/5 :h p5/4
+notes *3/4* :8 t12p7/4 s5s3/4 :8 3s:16:5-7/5 :h p5/4
 text :w, |#segno, ,|, :hd, , #tr
 
 


### PR DESCRIPTION
A time signature can be specified mid-stave in the form of \*#/#\*.
Ie. \*3/4\*, \*7/8\* etc:

![timesignote](https://user-images.githubusercontent.com/10076864/32407131-24521dac-c18d-11e7-852a-31150af4b09e.png)

Limitations:
- mid-stave time signature does not support common and cut-common time signatures
- beam groupings are not changed by the new time signature

If you can provide some brief guidelines where to begin solving these limitations, please do so and I try to solve them.

Note: The tests fail, but this was not introduced by me, it is failing on the master branch too. I made an issue about this: #97