### PR TITLE
Webpack libraryTarget set to UMD

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = (env) => {
     },
     output: {
       library: 'vextab',
+      libraryTarget: 'umd',
       filename: hasTag ? `[name].${tag}.js` : '[name].[contenthash].js',
       path: path.resolve(__dirname, 'dist'),
     },


### PR DESCRIPTION
fixes #112 

Specified library target to be UMD, which makes the api importable.
All the existing code examples and tests work. 