### PR TITLE
Add tutorial steps

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -69,6 +69,10 @@ code { font-family: Courier; font-size: 14px; color: green; }
 
 table.tabstave-keywords { font-family:monospace; margin:20px;}
 table.tabstave-keywords td {padding-right:30px;}
+
+table.fingering-keywords { font-family:monospace; margin:20px;}
+table.fingering-keywords td { padding-right:30px; vertical-align:top; }
+
 div.vex-canvas {
   background-color: white;
 }

--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -585,6 +585,48 @@ voice
 notes :q 7/6 7/6 0/5 0/5                    | 4/6 0/5 7/6 4/6 |
     </div>
 
+<h2>Step 17: Add fingerings.</h2>
+    <div class="description">
+      You can also add <code>fingering</code> after a given note.
+      <p />
+      The format for a <code>fingering</code> is:
+      <p />
+      <code>fingering/<i>[note number]</i>:<i>[position]</i>:<i>[type]</i>:<i>[value]</i></code>
+
+      <table class="fingering-keywords" style="vertical-align: top;">
+        <thead>
+          <tr><td><strong>element</strong></td><td><strong>values</strong></td></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>note number</td>
+            <td>The index of the note you for which you're adding the notation.  For single notes, this will be 1, and for chords it will be the position of the note in the notated chord</td>
+          </tr>
+          <tr>
+            <td>position</td>
+            <td>The position that the annotation will appear.  One of a, b, l, or r (for above, below, right or left).</td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>The type of annotation.  f or s (finger or string)</td>
+          </tr>
+          <tr>
+            <td>value</td>
+            <td>The annotation to add to the rendered staff</td>
+          </tr>
+        </tbody>
+      </table>
+
+     </div>
+
+    <div style="width:570; margin-left: auto; margin-right: auto;">
+    <div class="vex-tabdiv"
+      width=550 scale=1.0 editor="true"
+         editor_height=100>options stave-distance=30
+tabstave notation=true
+notes :8 6/4 $.fingering/1:l:f:2.$ h7/4 $.fingering/1:l:f:3.$ :q 0/2 :8 T0/2 5/3 $.fingering/1:l:f:4.$ :q 3/2 $.fingering/1:r:f:3.$
+    </div>
+
     <center>
     <h2>Step N + 1: Coming soon</h2>
       <p/>

--- a/doc/tutorial.html
+++ b/doc/tutorial.html
@@ -564,6 +564,26 @@ tabstave time=4/4 key=A
 notes :8 5/5 5/4 5/3 ^3^ :16 5-6-7-8/1 :8 9s10/1 :h s9v/1</div>
     </div>
 
+<h2>Step 16: Add multiple voices for polyphonic music.</h2>
+    <div class="description">
+      Add multiple <code>voice</code> lines before <code>notes</code> lines to correctly notate polyphonic music.  The stem directions are inferred from the voice order: the first voice (soprano) has stems up, and the last (bass) stems down.  The voices are combined onto a single staff.
+     </div>
+
+    <div style="width:570; margin-left: auto; margin-right: auto;">
+    <div class="vex-tabdiv"
+      width=550 scale=1.0 editor="true"
+      editor_height=100>options stave-distance=30
+tabstave notation=true
+    time=4/4
+voice
+notes :8 6/4 h7/4 :q 0/2 :8 T0/2 5/3 :q 3/2 | :q T3/2    :16 3/2 0/1 :8 6/2 :q T6/2 :q 0/1 |
+voice
+notes :w ##                                 | :8 ##  5/3 :8  0/2        7/4 6/4 7/4 :q 0/2 |
+voice
+notes :q ## :8 0/4 7/5 :qd 3/4 :8 0/4       | :q 2/4 |
+voice
+notes :q 7/6 7/6 0/5 0/5                    | 4/6 0/5 7/6 4/6 |
+    </div>
 
     <center>
     <h2>Step N + 1: Coming soon</h2>


### PR DESCRIPTION
The vextab tutorial (https://www.vexflow.com/vextab/tutorial.html)  doesn't yet mention that vextab supports multiple voices or fingerings, though there are tests showing that it's possible.  This PR is a documentation-only update.  I tried to match the style and tone of the prior sections, but please edit them as you see fit.

I did note that the TAB section doesn't render correctly when the score is complicated, is that why this hasn't been documented yet?

![vexflow-tut-step-16](https://user-images.githubusercontent.com/1637133/114336431-ce1ac480-9b03-11eb-86c7-b369d32808c7.png)

Cheers and regards.  Vexflow and Vextab are incredible pieces of work! jz
