### PR TITLE
Fix notation-vs-tab bar misalignment

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -214,6 +214,7 @@ class Artist
       if last_note instanceof Vex.Flow.BarNote
         notes.pop()
         stave.setEndBarType(last_note.getType())
+        stave.formatted = true
 
     for stave in @staves
       L "Rendering staves."

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -93,6 +93,49 @@ class VexTabTests
     tab.getArtist().render(renderer)
     assert.ok(true, "all pass")
 
+  makeCanvas = (vex, test_id, flex)->
+    c = $('<div></div>').css('flex', flex).css('font-size', '0.8em')
+    p = $('<p></p>').css('margin-top', '0px')
+    p.append($('<pre></pre>').text(vex).css('font-family', 'courier'))
+    c.append(p)
+    canvas = $('<div></div>').addClass("vex-tabdiv").attr('id', test_id).css('flex', flex)
+    c.append(canvas)
+    return c
+
+  renderCodeInCanvasId = (code, canvasid) ->
+    tab = new VexTab(new Artist(0, 0, 500, {scale: 0.8}))
+    tab.parse(code)
+    canvas = $('#' + canvasid)
+    renderer = new Vex.Flow.Renderer(canvas[0], Vex.Flow.Renderer.Backends.SVG)
+    renderer.getContext().setBackgroundFillStyle("#eed")
+    tab.getArtist().render(renderer)
+
+  # Render content to a new div, and return the content.
+  # Remove some things that change but aren't relevant (IDs)
+  getRenderedContent = (container, code, cssflex) ->
+    idcounter += 1
+    canvasid = 'rendered-' + idcounter
+    container.append(makeCanvas(code, canvasid, cssflex))
+    renderCodeInCanvasId(code, canvasid)
+    content = $('#' + canvasid).
+      html().
+      replace(/id=\".*?\"/g, 'id="xxx"')
+    return content
+
+  # ID counter for the equivalence tests
+  idcounter = 0
+
+  # Ensure that the rendered content of vex1 and vex2 are equivalent.
+  assertEquivalent = (assert, title, vex1, vex2) ->
+    test_div = $('<div></div>').addClass("testcanvas")
+    test_div.append($('<div></div>').addClass("name").text(title))
+    container = $('<div></div>').css('display', 'flex')
+    test_div.append(container)
+    $("body").append(test_div)
+    oldhtml = getRenderedContent(container, vex1, '0 0 30%')
+    newhtml = getRenderedContent(container, vex2, '1')
+    assert.equal(oldhtml, newhtml, title)
+
   @basic: (assert) ->
     assert.expect 3
     tab = makeParser()

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -262,13 +262,22 @@ class VexTabTests
     assert.ok true, "all pass"
 
   @bar: (assert) ->
-    assert.expect 5
+    assert.expect 7
     tab = makeParser()
 
     assert.notEqual null, tab.parse("tabstave\n notes |10s11/3")
     assert.notEqual null, tab.parse("tabstave\n notes 10s11h12p10/3|")
     assert.notEqual null, tab.parse("tabstave notation=true key=A\n notes || :w || 5/5 ||| T5/5 | T5V/5")
     catchError(assert, tab, "tabstave\n | notes 10/2s10")
+
+    code = """tabstave notation=true key=E time=12/8
+        notes :w 7/4 | :w 6/5"""
+    assertEquivalent(assert, "Sole notes line ends with bar", code, code + " |")
+
+    code = """tabstave notation=true key=E time=12/8
+        notes :w 7/4 |
+        notes :w 6/5"""
+    assertEquivalent(assert, "Last notes line ends with bar", code, code + " |")
 
     assert.ok true, "all pass"
 
@@ -544,19 +553,6 @@ class VexTabTests
     """
     renderTest assert, "Render Complex", code
 
-    code = """
-    tabstave notation=true key=E time=12/8
-        notes :w 7/4 | :w 6/5"""
-    renderTest assert, "Render ok when notes line does not end with bar", code
-    renderTest assert, "Render misaligns when notes line ends with bar", code + " |"
-
-    code = """
-    tabstave notation=true key=E time=12/8
-        notes :w 7/4 |
-        notes :w 6/5"""
-
-    renderTest assert, "Render ok when last notes line does not end with bar", code
-    renderTest assert, "Render misaligns when last notes line ends with bar", code + " |"
 
   @tabStems: (assert) ->
     code = """

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -93,26 +93,30 @@ class VexTabTests
     tab.getArtist().render(renderer)
     assert.ok(true, "all pass")
 
-  makeCanvas = (vex, test_id, flex)->
-    c = $('<div></div>').css('flex', flex).css('font-size', '0.8em')
-    p = $('<p></p>').css('margin-top', '0px')
-    p.append($('<pre></pre>').text(vex).css('font-family', 'courier'))
-    c.append(p)
-    canvas = $('<div></div>').addClass("vex-tabdiv").attr('id', test_id).css('flex', flex)
-    c.append(canvas)
-    return c
-
-  renderCodeInCanvasId = (code, canvasid) ->
-    tab = new VexTab(new Artist(0, 0, 500, {scale: 0.8}))
-    tab.parse(code)
-    canvas = $('#' + canvasid)
-    renderer = new Vex.Flow.Renderer(canvas[0], Vex.Flow.Renderer.Backends.SVG)
-    renderer.getContext().setBackgroundFillStyle("#eed")
-    tab.getArtist().render(renderer)
+  # ID counter for getRenderedContent.
+  idcounter = 0
 
   # Render content to a new div, and return the content.
   # Remove some things that change but aren't relevant (IDs)
   getRenderedContent = (container, code, cssflex) ->
+
+    makeCanvas = (vex, test_id, flex)->
+      c = $('<div></div>').css('flex', flex).css('font-size', '0.8em')
+      p = $('<p></p>').css('margin-top', '0px')
+      p.append($('<pre></pre>').text(vex).css('font-family', 'courier'))
+      c.append(p)
+      canvas = $('<div></div>').addClass("vex-tabdiv").attr('id', test_id).css('flex', flex)
+      c.append(canvas)
+      return c
+
+    renderCodeInCanvasId = (code, canvasid) ->
+      tab = new VexTab(new Artist(0, 0, 500, {scale: 0.8}))
+      tab.parse(code)
+      canvas = $('#' + canvasid)
+      renderer = new Vex.Flow.Renderer(canvas[0], Vex.Flow.Renderer.Backends.SVG)
+      renderer.getContext().setBackgroundFillStyle("#eed")
+      tab.getArtist().render(renderer)
+
     idcounter += 1
     canvasid = 'rendered-' + idcounter
     container.append(makeCanvas(code, canvasid, cssflex))
@@ -121,9 +125,6 @@ class VexTabTests
       html().
       replace(/id=\".*?\"/g, 'id="xxx"')
     return content
-
-  # ID counter for the equivalence tests
-  idcounter = 0
 
   # Ensure that the rendered content of vex1 and vex2 are equivalent.
   assertEquivalent = (assert, title, vex1, vex2) ->

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -100,16 +100,19 @@ class VexTabTests
   # Remove some things that change but aren't relevant (IDs)
   getRenderedContent = (container, code, cssflex) ->
 
-    makeCanvas = (vex, test_id, flex)->
-      c = $('<div></div>').css('flex', flex).css('font-size', '0.8em')
+    idcounter += 1
+    canvasid = 'rendered-' + idcounter
+
+    makeCanvas = ->
+      c = $('<div></div>').css('flex', cssflex).css('font-size', '0.8em')
       p = $('<p></p>').css('margin-top', '0px')
-      p.append($('<pre></pre>').text(vex).css('font-family', 'courier'))
+      p.append($('<pre></pre>').text(code).css('font-family', 'courier'))
       c.append(p)
-      canvas = $('<div></div>').addClass("vex-tabdiv").attr('id', test_id).css('flex', flex)
+      canvas = $('<div></div>').addClass("vex-tabdiv").attr('id', canvasid)
       c.append(canvas)
       return c
 
-    renderCodeInCanvasId = (code, canvasid) ->
+    renderCodeInCanvas = ->
       tab = new VexTab(new Artist(0, 0, 500, {scale: 0.8}))
       tab.parse(code)
       canvas = $('#' + canvasid)
@@ -117,10 +120,8 @@ class VexTabTests
       renderer.getContext().setBackgroundFillStyle("#eed")
       tab.getArtist().render(renderer)
 
-    idcounter += 1
-    canvasid = 'rendered-' + idcounter
-    container.append(makeCanvas(code, canvasid, cssflex))
-    renderCodeInCanvasId(code, canvasid)
+    container.append(makeCanvas())
+    renderCodeInCanvas()
     content = $('#' + canvasid).
       html().
       replace(/id=\".*?\"/g, 'id="xxx"')

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -501,6 +501,20 @@ class VexTabTests
     """
     renderTest assert, "Render Complex", code
 
+    code = """
+    tabstave notation=true key=E time=12/8
+        notes :w 7/4 | :w 6/5"""
+    renderTest assert, "Render ok when notes line does not end with bar", code
+    renderTest assert, "Render misaligns when notes line ends with bar", code + " |"
+
+    code = """
+    tabstave notation=true key=E time=12/8
+        notes :w 7/4 |
+        notes :w 6/5"""
+
+    renderTest assert, "Render ok when last notes line does not end with bar", code
+    renderTest assert, "Render misaligns when last notes line ends with bar", code + " |"
+
   @tabStems: (assert) ->
     code = """
     options tab-stems=true


### PR DESCRIPTION
Hi @0xfe / Mohit,

This PR fixes a bar misalignment mentioned in https://github.com/0xfe/vextab/issues/99, and PR https://github.com/0xfe/vextab/pull/120.  Prior to this PR, this works (bars aligned)

```
tabstave notation=true key=E time=12/8
notes :w 7/4 | 6/5
```

But this breaks (bars misaligned)

```
tabstave notation=true key=E time=12/8
notes :w 7/4 | 6/5 |
```

In this branch I added some very simple tests verifying the fix: code is rendered and the SVG is compared, eg:

![image](https://user-images.githubusercontent.com/1637133/115323077-31c47380-a13c-11eb-9020-ec3787412ce2.png)

Note that I pulled the single-line code fix from issue #99  -- I couldn't quite see why this fixed the issue, but it did!  The existing tests pass.

