### PR TITLE
WORK-IN-PROGRESS: user beaming -- DO NOT MERGE

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -68,6 +68,8 @@ class Artist
     @current_octave_shift = 0
     @bend_start_index = null
     @bend_start_strings = null
+    @in_beam = false
+    @beam_notes = []
     @rendered = false
     @renderer_context = null
 
@@ -340,6 +342,8 @@ class Artist
       stave_note.addDotToAll()
 
     stave_note.setPlayNote(params.play_note) if params.play_note?
+    if @in_beam
+      @beam_notes.push stave_note
     stave_notes.push stave_note
 
   addTabNote: (spec, play_note=null) ->
@@ -387,6 +391,22 @@ class Artist
     bar_note = new Vex.Flow.BarNote().setType(type)
     stave.tab_notes.push(bar_note)
     stave.note_notes.push(bar_note) if stave.note?
+
+  openBeam: (type) ->
+    L "openBeam: ", type
+    if @in_beam
+      throw new Vex.RERR("ArtistError", "Already in beam")
+    @in_beam = true
+    @beam_notes = []
+
+  closeBeam: (type) ->
+    L "closeBeam: ", type
+    if not @in_beam
+      throw new Vex.RERR("ArtistError", "Not in beam")
+    b = new Vex.Flow.Beam(@beam_notes, true)
+    @stave_articulations.push b
+    @in_beam = false
+    @beam_notes = []
 
   makeBend = (from_fret, to_fret) ->
     direction = Vex.Flow.Bend.UP

--- a/src/vextab.coffee
+++ b/src/vextab.coffee
@@ -73,20 +73,23 @@ class VexTab
     return params
 
   parseCommand: (element) ->
-    if element.command is "bar"
-      @artist.addBar(element.type)
-
-    if element.command is "tuplet"
-      @artist.makeTuplets(element.params.tuplet, element.params.notes)
-
-    if element.command is "annotations"
-      @artist.addAnnotations(element.params)
-
-    if element.command is "rest"
-      @artist.addRest(element.params)
-
-    if element.command is "command"
-      @artist.runCommand(element.params, element._l, element._c)
+    switch element.command
+      when "bar"
+        @artist.addBar(element.type)
+      when "tuplet"
+        @artist.makeTuplets(element.params.tuplet, element.params.notes)
+      when "annotations"
+        @artist.addAnnotations(element.params)
+      when "rest"
+        @artist.addRest(element.params)
+      when "command"
+        @artist.runCommand(element.params, element._l, element._c)
+      when "open_beam"
+        @artist.openBeam(element.params)
+      when "close_beam"
+        @artist.closeBeam(element.params)
+      else
+        throw newError(element.command, "Invalid command '#{element.command}'")
 
   parseChord: (element) ->
     L "parseChord:", element

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -53,6 +53,7 @@ class VexTabTests
     test "Rests in Tab", @restsInTab
     test "Multi String Tab", @multiStringTab
     test "Time Signature based Beaming", @timeSigBeaming
+    test "User Beaming", @beaming
     test "Override Fret-Note", @overrideFretNote
     test "Mixed Tuplets", @mixedTuplets
     test "Accidental Strategies", @accidentalStrategies
@@ -594,6 +595,13 @@ class VexTabTests
     notes :8 C-D-E-F/4 ## A-B/4 C-D-E-F-:16:G-F/5
     """
     renderTest assert, "Time Signature based Beaming", code
+
+  @beaming: (assert) ->
+    code = """
+    tabstave notation=true tablature=true time=4/4
+    notes :32 [ 2/3 5/2 ] :q 5/1
+    """
+    renderTest assert, "User Beaming", code
 
   @multiStringTab: (assert) ->
     code = """


### PR DESCRIPTION
Opening a draft PR hoping that someone with more experience can weigh in.

Currently, vextab doesn't support user-requested beaming.  According to the jison, it should be allowed, eg:

```
tabstave notation=true tablature=false
notes [ :32 3/4 4/5 ] :q 5/6
```

Should produce something like beamed 32nd notes, followed by a quarter.  The jison (https://github.com/0xfe/vextab/blob/master/src/vextab.jison#L232) refers to commands "open_beam" and "close_beam", but those aren't implemented in artist.coffee, and are ignored.

This wip PR changes the "if/else" to "switch/case" for executing commands, which fails when the user adds `[ ... ]` in vextab.  I then implemented a bare-bone idea for keeping track of the beam groups, but it currently doesn't work, as the beams are rendered in addition to the existing note stems:

![image](https://user-images.githubusercontent.com/1637133/115806271-4eaab200-a39b-11eb-9f67-5880645d2de8.png)

I tried a few things like this:

```
    if @in_beam
      @beam_notes.push stave_note
    else
      stave_notes.push stave_note
```

but that didn't work (fails with `Note needs a TickContext assigned for an X-Value`)

Hopefully someone can point out what's wrong with this primitive idea, and then beaming can be properly implemented (that is, if it's needed!).
