### PR TITLE
Migrate VexTab to VexFlow 4.0.0.

### DIFF
--- a/src/artist.coffee
+++ b/src/artist.coffee
@@ -625,7 +625,7 @@ class Artist
         fingerings = @makeFingering(annotations[i])
         if fingerings?
           try
-            (note.addModifier(fingering.num, fingering.modifier) for fingering in fingerings)
+            (note.addModifier(fingering.modifier, fingering.num) for fingering in fingerings)
           catch e
             throw new Vex.RERR("ArtistError", "Bad note number in fingering: #{annotations[i]}")
 

--- a/src/vextab.coffee
+++ b/src/vextab.coffee
@@ -44,7 +44,7 @@ class VexTab
           notation_option = option
           throw error("'#{option.key}' must be 'true' or 'false'") if option.value not in ["true", "false"]
         when "key"
-          throw error("Invalid key signature '#{option.value}'") unless _.has(Vex.Flow.keySignature.keySpecs, option.value)
+          throw error("Invalid key signature '#{option.value}'") unless Vex.Flow.hasKeySignature(option.value)
         when "clef"
           clefs = ["treble", "bass", "tenor", "alto", "percussion", "none"]
           throw error("'clef' must be one of #{clefs.join(', ')}") if option.value not in clefs

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -197,7 +197,7 @@ class VexTabTests
 
     # KEY SIGNATURE TESTS
 
-    for key of Vex.Flow.keySignature.keySpecs
+    for key of Vex.Flow.getKeySignatures()
       assert.notEqual null, tab.parse("tabstave key=" + key)
       assert.notEqual null, tab.parse("tabstave notation=true key=" + key)
       assert.notEqual null, tab.parse("tabstave notation=true tablature=true key=" + key)


### PR DESCRIPTION
This patch makes VexTab compatible with the VexFlow 4.0.0-alpha at:

https://github.com/ronyeh/vexflow/tree/4.0.0-alpha

